### PR TITLE
Chore/upgrade workspace 20260525

### DIFF
--- a/src/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.csproj
@@ -10,7 +10,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Syrx.Commanders.Databases.Connectors.Npgsql/Syrx.Commanders.Databases.Connectors.Npgsql.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.Npgsql/Syrx.Commanders.Databases.Connectors.Npgsql.csproj
@@ -10,8 +10,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.5" />
-		<PackageReference Include="Npgsql" Version="10.0.2" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+		<PackageReference Include="Npgsql" Version="10.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
@@ -14,7 +14,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.5" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
@@ -40,3 +40,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Npgsql.Extensions.Tests.Unit.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -35,3 +35,4 @@
   </ItemGroup>
 
 </Project>
+

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Npgsql.Tests.Unit/Syrx.Commanders.Databases.Connectors.Npgsql.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Npgsql.Tests.Unit/Syrx.Commanders.Databases.Connectors.Npgsql.Tests.Unit.csproj
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
@@ -37,3 +37,4 @@
   </ItemGroup>
 
 </Project>
+


### PR DESCRIPTION
This pull request primarily updates package dependencies across the main project, its submodules, and associated test projects. The goal is to keep the codebase up to date with the latest compatible versions, improving security, compatibility, and access to new features. There are no logic or functionality changes in the code itself.

Dependency updates:

**Production dependencies:**
* Updated `Microsoft.Extensions.DependencyInjection` from 10.0.5 to 10.0.8 in both `Syrx.Commanders.Databases.Connectors.Npgsql` and its `Extensions` project files. [[1]](diffhunk://#diff-6ec264e868e12e82433f0e1c6899adfc2caf572cc8734a34096e7c848b0f96b3L13-R14) [[2]](diffhunk://#diff-c17874d0f97b21183eb1c3aa05712a67926d27ffc60869017438fd2d72622f08L13-R13)
* Updated `Npgsql` from 10.0.2 to 10.0.3 in `Syrx.Commanders.Databases.Connectors.Npgsql.csproj`.

**Test dependencies:**
* Updated `coverlet.collector` from 8.0.1 to 10.0.1, and `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.6.0 in all test project files. [[1]](diffhunk://#diff-ae6db023db9d554d1fe997dc2db32355e1bd126de3e663664e6c6eb13dd1c43bL13-R18) [[2]](diffhunk://#diff-f9211e96b1c52e678b2425d87142e4fdf140e45f3ba1bb9326eb06d622e59228L13-R17) [[3]](diffhunk://#diff-a7bdd1d2f79dfff79201e97dfdf649b21cfed5111c24bcc73e80051867ccb2deL13-R17)
* Updated `Microsoft.Extensions.Logging.Console` from 10.0.5 to 10.0.8, and `Microsoft.NET.Test.Sdk` from 18.3.0 to 18.6.0 in the integration test project.

**Submodule update:**
* Updated the `Syrx.Commanders.Databases` submodule to the latest commit (`f46528c20ec4a3c1c56206bf9e0540414e512b63`).