### PR TITLE
deps: upgrade npgsql residual testcontainers package

### DIFF
--- a/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Npgsql.Tests.Integration/Syrx.Npgsql.Tests.Integration.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="Testcontainers.PostgreSql" Version="4.11.0" />
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates a dependency in the integration test project to ensure compatibility and access to the latest features and fixes.

Dependency updates:

* Upgraded the `Testcontainers.PostgreSql` NuGet package from version 4.11.0 to 4.12.0 in `Syrx.Npgsql.Tests.Integration.csproj`.